### PR TITLE
Add simulation chart

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -8,3 +8,4 @@ autopublish
 insecure
 iron:router
 
+mfpierre:chartist-js

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -32,6 +32,7 @@ livedata@1.0.13
 logging@1.0.7
 meteor@1.1.6
 meteor-platform@1.2.2
+mfpierre:chartist-js@1.6.0
 minifiers@1.1.5
 minimongo@1.0.8
 mobile-status-bar@1.0.3

--- a/Monty1.css
+++ b/Monty1.css
@@ -71,9 +71,9 @@ p {
 }
 
 .chart-visible p:first-of-type {
-  color: pink;
+  color: #f05b4f;
 }
 
 .chart-visible p:last-of-type {
-  color: red;
+  color: #d70206;
 }

--- a/Monty1.css
+++ b/Monty1.css
@@ -62,3 +62,18 @@ p {
 .punt{
   background-color: white;
 }
+
+.chart-visible {
+  height: 500px;
+  padding-bottom: 200px;
+  padding-top: 20px;
+  background-color: white;
+}
+
+.chart-visible p:first-of-type {
+  color: pink;
+}
+
+.chart-visible p:last-of-type {
+  color: red;
+}

--- a/Monty1.html
+++ b/Monty1.html
@@ -48,6 +48,8 @@
   <p>Games played is {{gamecount}}.</p>
   <p>Prizes won is {{wincount}}.</p>
   <!-- <p>Door counts: {{doorcounts}}.</p> -->
+  <p> Run simulation with <input id="iterations-input" type="text" value="1000"> iterations <button class="run">Run</button></p>
+  <div class="ct-chart"></div>
   </div>
   <div id="Buttons">
   <div class="again step3button">Play Again</div>

--- a/Monty1.js
+++ b/Monty1.js
@@ -128,8 +128,6 @@ if (Meteor.isClient) {
       Session.set("wincount", Session.get("wincount") + 1)
     };
 
-    Session.set("strategycounts", play1000()); // Run game 1000 times to check stats
-
     Router.go("/steps/3");
   }
 
@@ -154,17 +152,56 @@ if (Meteor.isClient) {
     },
     'click .restart': function() {
       initialize()
+    },
+    'click .run': function() {
+      runSimulation()
     }
   })
 
-  function play1000() {
+  function drawChart(series1, series2, labels) {
+
+    var descriptions = [
+      "Switch strategy is pink.",
+      "Stay strategy is red."
+    ]
+
+    var chartDiv = document.querySelector(".ct-chart")
+
+    // If we haven't displayed the chart before, add descriptions.
+    if (!chartDiv.classList.contains("chart-visible")) {
+      descriptions.forEach(function(description) {
+        var p = document.createElement("p")
+        p.innerText = description
+        chartDiv.appendChild(p)
+      })
+    }
+
+    // Add class to chartDiv
+    chartDiv.classList.add("chart-visible")
+
+    new Chartist.Line(".ct-chart", {
+      labels: labels,
+      series: [
+        series1,
+        series2
+      ]
+    });
+  }
+
+  function runSimulation() {
+
+    var iterations = document.getElementById("iterations-input").value;
+
+    var labels = []
+    var stctSeries = []
+    var swctSeries = []
     var pd, cd, ed, td, fd, dc
     var fdst, fdsw, fdfl
     var stct = 0,
       swct = 0,
       flct = 0
 
-    for (var i = 0; i < 1000; i++) {
+    for (var i = 0; i < iterations; i++) {
       pd = _.random(1, 3)
 
       dc = Session.get("doorcounts"); // Count all random door selections
@@ -180,7 +217,13 @@ if (Meteor.isClient) {
       if (fdst == pd) ++stct
       if (fdsw == pd) ++swct
       if (fdfl == pd) ++flct
+
+      labels.push(i)
+      stctSeries.push(stct)
+      swctSeries.push(swct)
     }
+
+    drawChart(stctSeries, swctSeries, labels)
     return [stct, swct, flct]
   }
 }


### PR DESCRIPTION
This PR adds a chart to display the results from a Monty Hall simulation. After step 3, you can now run the simulation for any given number of iterations (provided by the user in a text input field) and visualize the results.

<img width="1440" alt="screen shot 2018-02-24 at 3 49 26 pm" src="https://user-images.githubusercontent.com/5719322/36636371-632b42ca-197a-11e8-97d0-1e2be56bdfe8.png">



